### PR TITLE
Fix smileys/icon height

### DIFF
--- a/css/all.css
+++ b/css/all.css
@@ -52,3 +52,7 @@ em.u {
 em em.u {
     font-style: italic;
 }
+
+img.icon.smiley {
+    height: 1.2em;
+}


### PR DESCRIPTION
Smileys and FIXME etc. height not set. (e.g, if you look at the :wiki:syntax page they all appear huge.)

Added img.icon.smiley to reflect change here from DW for SVG based icons:

https://github.com/splitbrain/dokuwiki/commit/b09504a9ba668bc5e29701fd7c786d5757822b7a